### PR TITLE
build(browserslist): update config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yearn-finance-v3",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "private": true,
   "scripts": {
     "start": "craco start",
@@ -81,15 +81,10 @@
     "locize-cli": "7.6.17"
   },
   "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
+    "extends": ["react-app", "react-app/jest"]
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --write"
-    ]
+    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": ["prettier --write"]
   },
   "husky": {
     "hooks": {
@@ -98,14 +93,22 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
+      ">0.3%",
+      "not IE > 0",
+      "not op_mini all",
       "not dead",
-      "not op_mini all"
+      "last 2 Edge major versions",
+      "last 1 Chrome version",
+      "last 2 iOS major versions",
+      "last 1 Firefox version",
+      "not iOS 12.5",
+      "Chrome 99"
     ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      "last 1 edge version"
     ]
   }
 }


### PR DESCRIPTION
this configuration for browserslist explicitly drops IE support and unsafe browser versions. This should reduce build size/polyfill usage in production compiled output